### PR TITLE
minor version bump

### DIFF
--- a/exception_notifier.gemspec
+++ b/exception_notifier.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'exception_notifier'
-  s.version = '0.1.3'
+  s.version = '0.1.4'
   s.summary = "A wrapper for GiveLively's exception notifier"
   s.authors = ['Tim Lawrenz', 'Joe Anzalone', 'Dave Urban']
   s.date = '2020-02-20'


### PR DESCRIPTION
I could have sworn I did this, but I missed it. When I bundle locally I get 
```
Could not find gem 'exception_notifier (= 0.1.4)' in https://github.com/givelively/exception_notifier.git (at master@36378bf).
The source contains 'exception_notifier' at: 0.1.3
```

I think this will fix that.